### PR TITLE
Specify version for pygls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 typing-extensions
-git+https://github.com/openlawlibrary/pygls.git@
+git+https://github.com/openlawlibrary/pygls.git@master


### PR DESCRIPTION
Installing as per docs, with `pip install -r requirements.txt` results in the following error:

```bash
(venv) kinow@ranma:~/Development/python/workspace/cwl-language-server$ pip install -r requirements.txt 
Collecting git+https://github.com/openlawlibrary/pygls.git@ (from -r requirements.txt (line 2))
ERROR: The URL 'git+https://github.com/openlawlibrary/pygls.git@' has an empty revision (after @) which is not supported. Include a revision after @ or remove @ from the URL.
WARNING: You are using pip version 22.0.4; however, version 22.1.2 is available.
You should consider upgrading via the '/home/kinow/Development/python/workspace/cwl-language-server/venv/bin/python -m pip install --upgrade pip' command.
```

I used the ~latest tag~ `master` (since the `README` file mentions it) from their GH repository to fix it.